### PR TITLE
Adding "--" to handle negative longitudes

### DIFF
--- a/SimVirtualLocation/Logic/Runner.swift
+++ b/SimVirtualLocation/Logic/Runner.swift
@@ -126,6 +126,7 @@ class Runner {
                     "--rsd",
                     RSDAddress,
                     RSDPort,
+                    "--",
                     "\(location.latitude)",
                     "\(location.longitude)"
                 ]


### PR DESCRIPTION
This was added as part an earlier [commit](https://github.com/nexron171/SimVirtualLocation/commit/66e5b44377ba112624fc0ed00b9fae883d0ed42f) and needs a small change to support   iOS17+ devices using rsd.