### PR TITLE
Don't block a cooperative thread per waypoint (follow-up to #30)

### DIFF
--- a/SimVirtualLocation/Logic/Runner.swift
+++ b/SimVirtualLocation/Logic/Runner.swift
@@ -24,7 +24,10 @@ class Runner {
 
     private var currentTask: Process?
     private var tasks: [Process] = []
-    private let maxTasksCount = 10
+    /// How many `simulate-location` child processes may be alive at once. Each holds a
+    /// DVT channel open; the newest one owns the currently simulated location, and that
+    /// location survives its channel closing, so older ones can be retired immediately.
+    private let maxLiveTasks = 2
 
     /// PIDs we terminated ourselves while trimming the task window. Their stderr is
     /// expected noise (SIGTERM traceback) and must not surface as a user-facing alert,
@@ -93,13 +96,35 @@ class Runner {
         task.standardOutput = outputPipe
         task.standardError = errorPipe
 
+        // `pymobiledevice3 simulate-location set` ends in `OSUTILS.wait_return()`, which
+        // parks in `signal.sigwait` and never exits on its own. Blocking here on
+        // `waitUntilExit()` therefore holds a Swift cooperative thread forever, and that
+        // pool is sized to the CPU core count — so a route stalls after exactly as many
+        // waypoints as the Mac has cores. Collect stderr from a termination handler.
+        task.terminationHandler = { [weak self] finished in
+            guard let self = self else { return }
+
+            let wasReaped = self.runnerQueue.sync {
+                self.reapedPIDs.remove(finished.processIdentifier) != nil
+            }
+            guard !wasReaped else { return }
+
+            guard let errorData = try? errorPipe.fileHandleForReading.readToEnd() else { return }
+            let errorText = String(decoding: errorData, as: UTF8.self)
+            guard !errorText.isEmpty else { return }
+
+            Task { @MainActor in
+                showAlert(errorText)
+            }
+        }
+
         do {
             try task.run()
+
+            // Retire older processes rather than calling stop(), which tears down every
+            // task and flips isStopped, silently aborting the run in progress.
             self.runnerQueue.async {
-                // Trim the oldest processes instead of calling stop(): stop() tears down
-                // every task and flips isStopped, which silently aborts an in-flight route.
-                // The newest task holds the current location, so reaping the oldest is safe.
-                while self.tasks.count >= self.maxTasksCount {
+                while self.tasks.count >= self.maxLiveTasks {
                     let old = self.tasks.removeFirst()
                     if old.isRunning {
                         self.reapedPIDs.insert(old.processIdentifier)
@@ -107,22 +132,6 @@ class Runner {
                     }
                 }
                 self.tasks.append(task)
-            }
-
-            task.waitUntilExit()
-
-            let wasReaped = self.runnerQueue.sync {
-                self.reapedPIDs.remove(task.processIdentifier) != nil
-            }
-
-            if !wasReaped, let errorData = try errorPipe.fileHandleForReading.readToEnd() {
-                let errorText = String(decoding: errorData, as: UTF8.self)
-
-                if !errorText.isEmpty {
-                    Task { @MainActor in
-                        showAlert(errorText)
-                    }
-                }
             }
         } catch {
             Task { @MainActor in
@@ -180,13 +189,35 @@ class Runner {
         task.standardOutput = outputPipe
         task.standardError = errorPipe
 
+        // `pymobiledevice3 simulate-location set` ends in `OSUTILS.wait_return()`, which
+        // parks in `signal.sigwait` and never exits on its own. Blocking here on
+        // `waitUntilExit()` therefore holds a Swift cooperative thread forever, and that
+        // pool is sized to the CPU core count — so a route stalls after exactly as many
+        // waypoints as the Mac has cores. Collect stderr from a termination handler.
+        task.terminationHandler = { [weak self] finished in
+            guard let self = self else { return }
+
+            let wasReaped = self.runnerQueue.sync {
+                self.reapedPIDs.remove(finished.processIdentifier) != nil
+            }
+            guard !wasReaped else { return }
+
+            guard let errorData = try? errorPipe.fileHandleForReading.readToEnd() else { return }
+            let errorText = String(decoding: errorData, as: UTF8.self)
+            guard !errorText.isEmpty else { return }
+
+            Task { @MainActor in
+                showAlert(errorText)
+            }
+        }
+
         do {
             try task.run()
+
+            // Retire older processes rather than calling stop(), which tears down every
+            // task and flips isStopped, silently aborting the run in progress.
             self.runnerQueue.async {
-                // Trim the oldest processes instead of calling stop(): stop() tears down
-                // every task and flips isStopped, which silently aborts an in-flight route.
-                // The newest task holds the current location, so reaping the oldest is safe.
-                while self.tasks.count >= self.maxTasksCount {
+                while self.tasks.count >= self.maxLiveTasks {
                     let old = self.tasks.removeFirst()
                     if old.isRunning {
                         self.reapedPIDs.insert(old.processIdentifier)
@@ -194,22 +225,6 @@ class Runner {
                     }
                 }
                 self.tasks.append(task)
-            }
-
-            task.waitUntilExit()
-
-            let wasReaped = self.runnerQueue.sync {
-                self.reapedPIDs.remove(task.processIdentifier) != nil
-            }
-
-            if !wasReaped, let errorData = try errorPipe.fileHandleForReading.readToEnd() {
-                let errorText = String(decoding: errorData, as: UTF8.self)
-
-                if !errorText.isEmpty {
-                    Task { @MainActor in
-                        showAlert(errorText)
-                    }
-                }
             }
         } catch {
             Task { @MainActor in


### PR DESCRIPTION
Follow-up to #30. That PR fixed two real problems but missed the actual cause, and route simulation still stalls on device. This removes the blocking wait that was the root of it.

## What #30 got right, and what it missed

#30 correctly identified that:

- the overflow guard called `stop()`, which flipped `isStopped` and silently aborted runs
- stderr from deliberately terminated children tripped `showAlert`, clearing `isSimulating`

Both fixes are kept here. But the stall persisted after #30, at exactly the same waypoint count, because neither addressed why the children accumulate in the first place.

## Root cause

`pymobiledevice3 developer dvt simulate-location set` ends with `OSUTILS.wait_return()`, which on macOS is:

```python
def wait_return(self):
    print("Press Ctrl+C to send a SIGINT or use 'kill' command to send a SIGTERM")
    signal.sigwait([signal.SIGINT, signal.SIGTERM])
```

It blocks in `sigwait` and never exits on its own — the child is meant to be signalled, and holds its DVT channel open until it is.

`Runner.runOnNewIos` / `runOnIos` then call `task.waitUntilExit()` on that child. Each waypoint is dispatched from `LocationController.run(location:)` as an unstructured `Task { try await runner.runOnNewIos(...) }`, so **every waypoint permanently consumes one Swift cooperative thread**. That pool is sized to the CPU core count. Once it is exhausted no `Task` can run, no further location pushes are issued, and the route silently stops.

The map keeps animating because `performMovement()` is driven by a plain `Timer`, independent of Swift concurrency — which is why the failure is invisible in the UI.

### Evidence

On an 8-core MacBook Air, the stall lands on waypoint 8 regardless of update frequency:

| Location update frequency | Time before stall | Waypoints delivered |
| --- | --- | --- |
| 5s | 35 sec | 8 |
| 15s | 1 min 44 sec | 8 |
| 5s, with #30 applied | — | 8 |

A limit that does not move with the clock, and does not move when #30 is applied, is a pool size — not a timeout and not a session cap.

## Change

Replace the blocking `waitUntilExit()` with `Process.terminationHandler`, so `runOnIos` and `runOnNewIos` return promptly and never hold a cooperative thread. stderr is read in the handler, keeping #30's `reapedPIDs` suppression intact.

Also lowers the live-child window from 10 to 2 (`maxLiveTasks`). With the blocking wait gone there is no reason to keep ten DVT sessions open; the newest child owns the current location, and holding fewer sessions avoids the `Connection reset by peer` bursts seen when many connect at once.

The other `waitUntilExit()` calls in `Runner` are untouched — those children (adb, device listing, `which`) exit on their own.

## Verification

Built with `xcodebuild` on a GitHub-hosted `macos-latest` runner and installed locally.

- **Before:** stalled at 8 waypoints on every run, both at 5s and 15s frequency, and still at 8 with #30 applied.
- **After:** the same A-to-B route at 5s frequency runs past that limit, the device keeps tracking in Maps, and no `Alert:` tracebacks appear in the log.

Tested on iPhone 15 Pro Max, iOS 26.5.2, USB, tunnel via `pymobiledevice3 remote start-tunnel -p tcp`.

## Notes

- Assumes a simulated location outlives the DVT channel that set it. This holds in practice: when the tunnel dropped entirely and every session died, the device stayed at the last simulated coordinate rather than reverting to real GPS.
- `runnerQueue.sync` inside `terminationHandler` is safe — the handler runs on Foundation's private queue, never on `runnerQueue`.
- A deeper redesign would replace per-waypoint `set` calls with a single `simulate-location play` against a generated GPX. `LocationSimulation.play_gpx_file` walks the whole route inside one DVT session, so children never accumulate at all. Happy to submit that separately if you'd prefer it.

## Environment

- macOS 26.2 (25C56), Apple Silicon, 8 cores
- pymobiledevice3 10.2.3
- iPhone 15 Pro Max, iOS 26.5.2