### PR TITLE
Connect to iOS 17+ devices without a manually started tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Posibilities:
 - set location to current Mac's location
 - set location to point on map
 - make route between two points and simulate moving with desired speed
+- pause and resume a route without starting it over, and change speed while it runs
 
 You can dowload compiled and signed app [here](https://github.com/nexron171/SimVirtualLocation/releases).
 
@@ -26,11 +27,21 @@ brew install python3 && python3 -m pip install -U pymobiledevice3
 
 For iOS Device - select device from dropdown and then click on Mound Developer Image. If you see an error that there is no appropriate image - download one from https://github.com/mspvirajpatel/Xcode_Developer_Disk_Images/releases if your iOS for example 16.5.1 and there is only 16.5 - it's ok, just copy and rename it to 16.5.1 and put it inside Xcode at `.../Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport/`
 
-For iOS 17+ select checkbox iOS 17+ and provide RSD Address and RSD Port from command:
+#### iOS 17 and newer
+
+Leave the **iOS 17+** checkbox ticked (it is on by default) and keep **Connection** on
+**Automatic**. Pick your iPhone from the **Device** dropdown and that is the whole setup —
+SimVirtualLocation opens the tunnel itself using pymobiledevice3's userspace network stack,
+so no Terminal window and no `sudo` are involved. Progress is shown under the dropdown while
+the tunnel comes up.
+
+Switch **Connection** to **Manual** only if you would rather use a kernel tunnel, which is
+faster for large transfers. Start it yourself, keep it running, and copy the two values it
+prints into the RSD Address and RSD Port fields:
+
 ```shell
 sudo python3 -m pymobiledevice3 remote start-tunnel
 ```
-It needs sudo, because it will instantiate low level connection between Mac and iPhone. Keep this command running while mocking location for iOS 17+.
 
 ### If iOS device is unlisted
 

--- a/SimVirtualLocation.xcodeproj/project.pbxproj
+++ b/SimVirtualLocation.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		AA000002280DE000001D3559 /* IOSProcessLaunching.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000012280DE000001D3559 /* IOSProcessLaunching.swift */; };
 		AA000003280DE000001D3559 /* MapSceneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000013280DE000001D3559 /* MapSceneCoordinator.swift */; };
 		AA000004280DE000001D3559 /* AppPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000014280DE000001D3559 /* AppPlatform.swift */; };
+		AA0000F5280DE000001D3559 /* DeviceActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000F6280DE000001D3559 /* DeviceActivity.swift */; };
+		AA0000F3280DE000001D3559 /* IOSConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000F4280DE000001D3559 /* IOSConnection.swift */; };
 		AA000005280DE000001D3559 /* AppStorageKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000015280DE000001D3559 /* AppStorageKey.swift */; };
 		AA000006280DE000001D3559 /* LocationModes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000016280DE000001D3559 /* LocationModes.swift */; };
 		AA000007280DE000001D3559 /* IOSUSBDeviceDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000017280DE000001D3559 /* IOSUSBDeviceDiscovery.swift */; };
@@ -18,7 +20,9 @@
 		AA000009280DE000001D3559 /* SavedLocationsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000019280DE000001D3559 /* SavedLocationsStore.swift */; };
 		AA00000A280DE000001D3559 /* SimulatorDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00001A280DE000001D3559 /* SimulatorDiscovery.swift */; };
 		AA00000B280DE000001D3559 /* CoordinateParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00001B280DE000001D3559 /* CoordinateParsing.swift */; };
+		AA0000F1280DE000001D3559 /* GPXRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000F2280DE000001D3559 /* GPXRoute.swift */; };
 		AA00000C280DE000001D3559 /* SimVirtualLocationAlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00001C280DE000001D3559 /* SimVirtualLocationAlertModifier.swift */; };
+		AA0000F7280DE000001D3559 /* DeviceActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000F8280DE000001D3559 /* DeviceActivityView.swift */; };
 		ED44823627B2590400C416C9 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = ED44823527B2590400C416C9 /* Info.plist */; };
 		ED5EB07E280DDDBD004D3559 /* iOSPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5EB07D280DDDBD004D3559 /* iOSPanel.swift */; };
 		ED5EB080280DE195004D3559 /* AndroidPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED5EB07F280DE195004D3559 /* AndroidPanel.swift */; };
@@ -47,6 +51,8 @@
 		AA000012280DE000001D3559 /* IOSProcessLaunching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSProcessLaunching.swift; sourceTree = "<group>"; };
 		AA000013280DE000001D3559 /* MapSceneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapSceneCoordinator.swift; sourceTree = "<group>"; };
 		AA000014280DE000001D3559 /* AppPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPlatform.swift; sourceTree = "<group>"; };
+		AA0000F6280DE000001D3559 /* DeviceActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceActivity.swift; sourceTree = "<group>"; };
+		AA0000F4280DE000001D3559 /* IOSConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSConnection.swift; sourceTree = "<group>"; };
 		AA000015280DE000001D3559 /* AppStorageKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorageKey.swift; sourceTree = "<group>"; };
 		AA000016280DE000001D3559 /* LocationModes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationModes.swift; sourceTree = "<group>"; };
 		AA000017280DE000001D3559 /* IOSUSBDeviceDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSUSBDeviceDiscovery.swift; sourceTree = "<group>"; };
@@ -54,7 +60,9 @@
 		AA000019280DE000001D3559 /* SavedLocationsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedLocationsStore.swift; sourceTree = "<group>"; };
 		AA00001A280DE000001D3559 /* SimulatorDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorDiscovery.swift; sourceTree = "<group>"; };
 		AA00001B280DE000001D3559 /* CoordinateParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateParsing.swift; sourceTree = "<group>"; };
+		AA0000F2280DE000001D3559 /* GPXRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPXRoute.swift; sourceTree = "<group>"; };
 		AA00001C280DE000001D3559 /* SimVirtualLocationAlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimVirtualLocationAlertModifier.swift; sourceTree = "<group>"; };
+		AA0000F8280DE000001D3559 /* DeviceActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceActivityView.swift; sourceTree = "<group>"; };
 		ED44823527B2590400C416C9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		ED5EB07D280DDDBD004D3559 /* iOSPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSPanel.swift; sourceTree = "<group>"; };
 		ED5EB07F280DE195004D3559 /* AndroidPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndroidPanel.swift; sourceTree = "<group>"; };
@@ -106,6 +114,7 @@
 			isa = PBXGroup;
 			children = (
 				AA00001B280DE000001D3559 /* CoordinateParsing.swift */,
+				AA0000F2280DE000001D3559 /* GPXRoute.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -121,6 +130,7 @@
 				ED5EB083280DE263004D3559 /* LocationSettingsPanel.swift */,
 				EDFC771E2B0A54860058B13A /* LocationsView.swift */,
 				AA00001C280DE000001D3559 /* SimVirtualLocationAlertModifier.swift */,
+				AA0000F8280DE000001D3559 /* DeviceActivityView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -165,6 +175,8 @@
 				EDFC77202B0A55050058B13A /* Locations.swift */,
 				EDDB312D2BFCE6FE0079D10D /* LogEntry.swift */,
 				AA000014280DE000001D3559 /* AppPlatform.swift */,
+				AA0000F6280DE000001D3559 /* DeviceActivity.swift */,
+				AA0000F4280DE000001D3559 /* IOSConnection.swift */,
 				AA000015280DE000001D3559 /* AppStorageKey.swift */,
 				AA000016280DE000001D3559 /* LocationModes.swift */,
 			);
@@ -297,6 +309,8 @@
 				AA000002280DE000001D3559 /* IOSProcessLaunching.swift in Sources */,
 				AA000003280DE000001D3559 /* MapSceneCoordinator.swift in Sources */,
 				AA000004280DE000001D3559 /* AppPlatform.swift in Sources */,
+				AA0000F5280DE000001D3559 /* DeviceActivity.swift in Sources */,
+				AA0000F3280DE000001D3559 /* IOSConnection.swift in Sources */,
 				AA000005280DE000001D3559 /* AppStorageKey.swift in Sources */,
 				AA000006280DE000001D3559 /* LocationModes.swift in Sources */,
 				AA000007280DE000001D3559 /* IOSUSBDeviceDiscovery.swift in Sources */,
@@ -304,7 +318,9 @@
 				AA000009280DE000001D3559 /* SavedLocationsStore.swift in Sources */,
 				AA00000A280DE000001D3559 /* SimulatorDiscovery.swift in Sources */,
 				AA00000B280DE000001D3559 /* CoordinateParsing.swift in Sources */,
+				AA0000F1280DE000001D3559 /* GPXRoute.swift in Sources */,
 				AA00000C280DE000001D3559 /* SimVirtualLocationAlertModifier.swift in Sources */,
+				AA0000F7280DE000001D3559 /* DeviceActivityView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SimVirtualLocation/Logic/DeviceLocationRunning.swift
+++ b/SimVirtualLocation/Logic/DeviceLocationRunning.swift
@@ -5,6 +5,8 @@ import Foundation
 protocol DeviceLocationRunning: IOSProcessLaunching {
     var timeDelay: TimeInterval { get set }
     var log: ((String) -> Void)? { get set }
+    var onActivity: ((DeviceActivity) -> Void)? { get set }
+    var onLocationPlayed: ((Double, Double) -> Void)? { get set }
     var pymobiledevicePath: String? { get set }
 
     func stop()
@@ -23,10 +25,25 @@ protocol DeviceLocationRunning: IOSProcessLaunching {
 
     func runOnNewIos(
         location: CLLocationCoordinate2D,
-        rsdAddress: String,
-        rsdPort: String,
+        connection: IOSConnection,
         showAlert: @escaping (String) -> Void
     ) async throws
+
+    func playRoute(
+        gpxURL: URL,
+        connection: IOSConnection,
+        showAlert: @escaping (String) -> Void
+    ) async throws
+
+    var isPlaybackRunning: Bool { get }
+
+    func stopRoutePlayback()
+
+    @discardableResult
+    func pauseRoutePlayback() -> Bool
+
+    @discardableResult
+    func resumeRoutePlayback() -> Bool
 
     func runOnAndroid(
         location: CLLocationCoordinate2D,

--- a/SimVirtualLocation/Logic/LocationController.swift
+++ b/SimVirtualLocation/Logic/LocationController.swift
@@ -14,9 +14,16 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
     // MARK: - Publishers
 
     @Published var isSimulating = false
-    @Published var speed: Double = 60.0
+    @Published var speed: Double = 60.0 {
+        didSet { scheduleSpeedChange() }
+    }
     @Published var pointsMode: PointsMode = .single {
-        didSet { mapScene.handlePointsModeChange(to: pointsMode) }
+        didSet {
+            mapScene.handlePointsModeChange(to: pointsMode)
+            if pointsMode == .single {
+                clearRouteState()
+            }
+        }
     }
 
     @Published var transportType: TransportType = .driving
@@ -25,7 +32,44 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
         didSet { defaults.set(xcodePath, forKey: AppStorageKey.xcodePath) }
     }
 
-    @Published var useRSD: Bool = false
+    @Published var useRSD: Bool = true
+
+    /// Establish the iOS 17+ tunnel in-process instead of relying on a tunnel the user starts
+    /// with `sudo` in Terminal. Removes the need for RSD Address / RSD Port entirely.
+    @Published var useUserspace: Bool = true {
+        didSet { defaults.set(useUserspace, forKey: AppStorageKey.useUserspace) }
+    }
+
+    /// True while an entire route is being replayed by a single `simulate-location play`
+    /// process, in which case `performMovement` animates the map but must not also push
+    /// locations itself.
+    private var isPlayingRoute = false
+
+    /// Progress of the current device operation, shown next to the device picker.
+    @Published var activity: DeviceActivity = .idle
+
+    /// True while a simulation is suspended and can be resumed from the same point.
+    @Published var isPaused = false
+
+    /// Length of the route currently loaded, in metres. Zero when none is loaded.
+    @Published private(set) var routeDistance: CLLocationDistance = 0
+
+    /// Journey time the user wants, in minutes. Applying it derives the speed.
+    @Published var targetDurationMinutes: String = ""
+
+    /// Route being played, and how much of it the device has already covered. Used to
+    /// rebuild the remainder when the speed changes mid-route.
+    private var playbackCoordinates: [CLLocationCoordinate2D] = []
+    private var playbackIndex = 0
+    private var speedChangeWork: DispatchWorkItem?
+
+    /// How often connected devices are rescanned. Scanning shells out to pymobiledevice3,
+    /// so poll briskly only while waiting for a device to appear and back off once one is
+    /// attached, where the scan exists just to notice a disconnect.
+    private static let deviceScanIntervalWaiting: TimeInterval = 3
+    private static let deviceScanIntervalAttached: TimeInterval = 15
+
+    private var deviceMonitorTask: Task<Void, Never>?
 
     @Published var bootedSimulators: [Simulator] = []
     @Published var selectedSimulator: String = ""
@@ -100,6 +144,26 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
         self.savedLocationsStore = savedLocationsStore
         super.init()
 
+        if defaults.object(forKey: AppStorageKey.useUserspace) != nil {
+            useUserspace = defaults.bool(forKey: AppStorageKey.useUserspace)
+        }
+
+        runner.onLocationPlayed = { [weak self] latitude, longitude in
+            DispatchQueue.main.async {
+                guard let self = self, self.isPlayingRoute else { return }
+                let coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+                self.playbackIndex += 1
+                self.mapScene.removeSimulationAnnotationFromMap()
+                self.mapScene.placeSimulationAnnotation(at: coordinate)
+            }
+        }
+
+        runner.onActivity = { [weak self] activity in
+            DispatchQueue.main.async {
+                self?.activity = activity
+            }
+        }
+
         runner.log = { [weak self] message in
             DispatchQueue.main.async {
                 self?.log(message)
@@ -119,6 +183,7 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
 
         Task {
             await refreshDevices()
+            startDeviceMonitoring()
 
             if let p = AppPlatform(rawValue: defaults.integer(forKey: AppStorageKey.platform)) {
                 platform = p
@@ -135,8 +200,19 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
     // MARK: - Public
 
     func refreshDevices() async {
+        await refreshDevices(silently: false)
+    }
+
+    /// - Parameter silently: when true this is a background rescan, so a failure is logged
+    ///   rather than raised — a device being unplugged is not an error worth alarming about.
+    func refreshDevices(silently: Bool) async {
         bootedSimulators = (try? SimulatorDiscovery.fetchBootedSimulators(log: { [weak self] in self?.log($0) })) ?? []
-        selectedSimulator = bootedSimulators.first?.id ?? ""
+        if selectedSimulator.isEmpty || !bootedSimulators.contains(where: { $0.id == selectedSimulator }) {
+            selectedSimulator = bootedSimulators.first?.id ?? ""
+        }
+
+        let previousSelection = selectedDevice
+        let previousDevices = connectedDevices
 
         do {
             connectedDevices = try await IOSUSBDeviceDiscovery.fetchConnectedDevices(
@@ -146,8 +222,78 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
             )
         } catch {
             connectedDevices = []
+            if !silently {
+                activity = .failed("Could not list devices — see Logs")
+            }
         }
-        selectedDevice = connectedDevices.first?.id ?? ""
+
+        // Keep the user's choice as long as that device is still attached.
+        if connectedDevices.contains(where: { $0.id == previousSelection }) {
+            selectedDevice = previousSelection
+        } else {
+            selectedDevice = connectedDevices.first?.id ?? ""
+        }
+
+        let changed = connectedDevices != previousDevices
+
+        if connectedDevices.isEmpty {
+            if changed, !previousDevices.isEmpty {
+                handleDeviceDisconnected()
+            } else if activity == .idle {
+                activity = .working("Waiting for a device…")
+            }
+            return
+        }
+
+        guard changed else { return }
+
+        if previousDevices.isEmpty {
+            activity = .active("Device connected")
+        } else {
+            activity = .idle
+        }
+        log("connected devices: \(connectedDevices.map { $0.name }.joined(separator: ", "))")
+    }
+
+    /// The device went away mid-session.
+    ///
+    /// iOS drops the simulated location as soon as the tunnel dies, so the phone is already
+    /// back on real GPS. Say so rather than leaving a stale "Location set" on screen, and
+    /// suspend any route instead of resuming it silently — re-spoofing a location the user
+    /// is no longer watching is worse than making them press Resume.
+    private func handleDeviceDisconnected() {
+        log("device disconnected")
+
+        guard isSimulating else {
+            activity = .failed("Device disconnected — location no longer simulated")
+            return
+        }
+
+        runner.stopRoutePlayback()
+        timer?.invalidate()
+        timer = nil
+        isPaused = true
+        activity = .failed("Device disconnected — simulation paused")
+    }
+
+    /// Rescan for devices on a timer so connecting a phone is noticed without the user
+    /// having to ask. Cancelled and restarted rather than left to stack up.
+    private func startDeviceMonitoring() {
+        deviceMonitorTask?.cancel()
+        deviceMonitorTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self = self else { return }
+
+                let interval = self.connectedDevices.isEmpty
+                    ? Self.deviceScanIntervalWaiting
+                    : Self.deviceScanIntervalAttached
+
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                guard !Task.isCancelled else { return }
+
+                await self.refreshDevices(silently: true)
+            }
+        }
     }
 
     func setCurrentLocation() {
@@ -176,8 +322,74 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
     }
 
     func makeRoute() {
-        mapScene.makeRoute(transportType: transportType, showAlert: showAlert)
+        mapScene.makeRoute(
+            transportType: transportType,
+            showAlert: showAlert,
+            onRouteReady: { [weak self] route in
+                self?.routeDistance = route.distance
+            }
+        )
     }
+
+    /// Forget everything derived from a route once that route is gone, so distance,
+    /// journey time and the duration control do not outlive what they describe.
+    private func clearRouteState() {
+        routeDistance = 0
+        targetDurationMinutes = ""
+        tracks = []
+        tracksTimes = [:]
+        playbackCoordinates = []
+        playbackIndex = 0
+    }
+
+    /// Distance and journey time for the loaded route at the current speed.
+    var routeSummary: String? {
+        guard routeDistance > 0 else { return nil }
+
+        let seconds = routeDistance / max(speed / 3.6, 0.1)
+        let minutes = Int((seconds / 60).rounded())
+        let duration = minutes >= 60
+            ? "\(minutes / 60)h \(minutes % 60)m"
+            : "\(max(minutes, 1)) min"
+
+        let distance = String(format: "%.2f km", routeDistance / 1000)
+        return "\(distance) · about \(duration) at \(Int(speed.rounded())) km/h"
+    }
+
+    /// Pick the speed that covers the loaded route in `targetDurationMinutes`.
+    ///
+    /// Speed is clamped to the slider's range, and the user is told when the requested
+    /// time is not achievable within it rather than being given a silently wrong speed.
+    func applyTargetDuration() {
+        guard routeDistance > 0 else {
+            showAlert("Make a route first, then set how long it should take.")
+            return
+        }
+
+        guard let minutes = Double(targetDurationMinutes.trimmingCharacters(in: .whitespaces)),
+              minutes > 0 else {
+            showAlert("Enter the journey time in minutes, for example 20.")
+            return
+        }
+
+        let required = routeDistance / (minutes * 60) * 3.6
+        let clamped = min(max(required, Self.minimumSpeed), Self.maximumSpeed)
+        speed = (clamped / 5).rounded() * 5
+
+        if required > Self.maximumSpeed || required < Self.minimumSpeed {
+            showAlert(
+                String(
+                    format: "That journey needs %.0f km/h, outside the %.0f–%.0f range. Speed set to %.0f km/h.",
+                    required, Self.minimumSpeed, Self.maximumSpeed, speed
+                )
+            )
+        }
+
+        log("target duration \(Int(minutes)) min over \(String(format: "%.2f", routeDistance / 1000)) km — speed set to \(Int(speed)) km/h")
+    }
+
+    static let minimumSpeed: Double = 5
+    static let maximumSpeed: Double = 200
 
     func simulateRoute() {
         guard let route = mapScene.route else {
@@ -206,12 +418,11 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
 
         log("Route segment distances: \(tracks.map { CLLocation.distance(from: $0.startPoint.coordinate, to: $0.endPoint.coordinate) })")
 
+        isPaused = false
         invalidateState()
+        isPlayingRoute = startRoutePlayback()
 
-        let timer = Timer.scheduledTimer(withTimeInterval: timeScale, repeats: true) { [weak self] _ in
-            self?.performMovement()
-        }
-        self.timer = timer
+        startMovementTimer()
     }
 
     func simulateFromAToB() {
@@ -230,12 +441,14 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
             )
         ]
 
-        invalidateState()
+        // A straight A-to-B run has no MKRoute, so measure the leg directly.
+        routeDistance = CLLocation.distance(from: endpoints[0].coordinate, to: endpoints[1].coordinate)
 
-        let timer = Timer.scheduledTimer(withTimeInterval: timeScale, repeats: true) { [weak self] _ in
-            self?.performMovement()
-        }
-        self.timer = timer
+        isPaused = false
+        invalidateState()
+        isPlayingRoute = startRoutePlayback()
+
+        startMovementTimer()
     }
 
     func updateMapRegion(force: Bool = false) {
@@ -305,11 +518,91 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
 
     func stopSimulation() {
         isSimulating = false
+        isPlayingRoute = false
+        isPaused = false
         runner.stop()
+    }
+
+    /// Suspend or resume the running simulation without losing progress.
+    func togglePauseSimulation() {
+        guard isSimulating else { return }
+
+        if isPaused {
+            if isPlayingRoute {
+                if runner.isPlaybackRunning {
+                    runner.resumeRoutePlayback()
+                } else {
+                    // Playback died with the connection; replay what is left of the route.
+                    restartPlaybackFromCurrentPosition()
+                }
+            }
+            isPaused = false
+            startMovementTimer()
+            log("simulation resumed")
+        } else {
+            if isPlayingRoute { runner.pauseRoutePlayback() }
+            isPaused = true
+            timer?.invalidate()
+            timer = nil
+            log("simulation paused")
+        }
+    }
+
+    /// Apply a speed change to a route already in flight.
+    ///
+    /// The GPX encodes speed as the gap between timestamps, so the only way to change it is
+    /// to rewrite the remainder of the route and restart playback from where the device
+    /// actually is. Debounced, because dragging the slider emits continuously.
+    private func scheduleSpeedChange() {
+        speedChangeWork?.cancel()
+        guard isSimulating, isPlayingRoute, !isPaused else { return }
+
+        let work = DispatchWorkItem { [weak self] in
+            self?.restartPlaybackFromCurrentPosition()
+        }
+        speedChangeWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: work)
+    }
+
+    private func restartPlaybackFromCurrentPosition() {
+        guard isSimulating, isPlayingRoute else { return }
+        guard !connectedDevices.isEmpty else {
+            activity = .failed("No device connected")
+            return
+        }
+
+        let remaining = Array(playbackCoordinates.suffix(from: min(playbackIndex, playbackCoordinates.count)))
+        guard remaining.count > 1 else { return }
+
+        runner.stopRoutePlayback()
+
+        do {
+            let url = try GPXRoute.write(coordinates: remaining, speed: speed / 3.6)
+            let connection = iosConnection
+            playbackCoordinates = remaining
+            playbackIndex = 0
+
+            Task {
+                try await runner.playRoute(gpxURL: url, connection: connection, showAlert: showAlert)
+            }
+
+            log("speed changed to \(Int(speed)) km/h — replaying \(remaining.count) remaining points")
+        } catch {
+            showAlert(error.localizedDescription)
+        }
+    }
+
+    private func startMovementTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: timeScale, repeats: true) { [weak self] _ in
+            self?.performMovement()
+        }
     }
 
     func reset() {
         mapScene.resetMapVisuals()
+        clearRouteState()
+
         if platform == .iOS {
             runner.resetIos(showAlert: showAlert)
         } else {
@@ -498,9 +791,50 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
         currentTrackIndex = 0
     }
 
+    /// How the iOS 17+ device should be reached.
+    private var iosConnection: IOSConnection {
+        useUserspace ? .userspace(udid: selectedDevice) : .rsd(address: rsdAddress, port: rsdPort)
+    }
+
+    /// Coordinates along the computed route, in order.
+    private func routeCoordinates() -> [CLLocationCoordinate2D] {
+        guard let last = tracks.last else { return [] }
+        return tracks.map { $0.startPoint.coordinate } + [last.endPoint.coordinate]
+    }
+
+    /// Hand the whole route to the device as one `simulate-location play` process.
+    ///
+    /// - Returns: `true` when playback started, meaning `performMovement` should only animate
+    ///   the map rather than pushing a location per waypoint.
+    private func startRoutePlayback() -> Bool {
+        guard platform == .iOS, deviceMode == .device else { return false }
+
+        let coordinates = routeCoordinates()
+        guard coordinates.count > 1 else { return false }
+
+        playbackCoordinates = coordinates
+        playbackIndex = 0
+
+        do {
+            let url = try GPXRoute.write(coordinates: coordinates, speed: speed / 3.6)
+            let connection = iosConnection
+
+            Task {
+                try await runner.playRoute(gpxURL: url, connection: connection, showAlert: showAlert)
+            }
+
+            log("route playback started (\(coordinates.count) points)")
+            return true
+        } catch {
+            showAlert(error.localizedDescription)
+            return false
+        }
+    }
+
     private func performMovement() {
         guard isSimulating, tracks.count > 0, currentTrackIndex < tracks.count else {
             isSimulating = false
+            isPaused = false
             timer?.invalidate()
             timer = nil
             currentTrackIndex = 0
@@ -519,14 +853,14 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
         switch trackMove {
         case .moveTo(to: let to, from: let from, withSpeed: let moveSpeed):
             lastTrackLocation = to
-            run(location: to)
+            if !isPlayingRoute { run(location: to) }
             mapScene.placeSimulationAnnotation(at: to)
             log("move to — distance=\(CLLocation.distance(from: from, to: to)), speed=\(moveSpeed)")
 
         case .finishTo(to: let to, from: let from, withSpeed: let moveSpeed):
             lastTrackLocation = nil
             currentTrackIndex += 1
-            run(location: to)
+            if !isPlayingRoute { run(location: to) }
             mapScene.placeSimulationAnnotation(at: to)
             log("finish to — distance=\(CLLocation.distance(from: from, to: to)), speed=\(moveSpeed)")
         }
@@ -594,8 +928,7 @@ class LocationController: NSObject, ObservableObject, CLLocationManagerDelegate 
                 Task {
                     try await runner.runOnNewIos(
                         location: location,
-                        rsdAddress: rsdAddress,
-                        rsdPort: rsdPort,
+                        connection: iosConnection,
                         showAlert: showAlert
                     )
                 }

--- a/SimVirtualLocation/Logic/MapSceneCoordinator.swift
+++ b/SimVirtualLocation/Logic/MapSceneCoordinator.swift
@@ -47,7 +47,11 @@ final class MapSceneCoordinator: NSObject, MKMapViewDelegate {
         pointAnnotations
     }
 
-    func makeRoute(transportType: TransportType, showAlert: @escaping (String) -> Void) {
+    func makeRoute(
+        transportType: TransportType,
+        showAlert: @escaping (String) -> Void,
+        onRouteReady: @escaping (MKRoute) -> Void = { _ in }
+    ) {
         guard pointAnnotations.count == 2 else {
             showAlert("Route requires two points")
             return
@@ -102,6 +106,8 @@ final class MapSceneCoordinator: NSObject, MKMapViewDelegate {
 
                 let rect = route.polyline.boundingMapRect
                 self.mapView.setRegion(MKCoordinateRegion(rect.insetBy(dx: -1000, dy: -1000)), animated: true)
+
+                onRouteReady(route)
             }
         }
     }

--- a/SimVirtualLocation/Logic/Runner.swift
+++ b/SimVirtualLocation/Logic/Runner.swift
@@ -16,6 +16,17 @@ class Runner {
     var log: ((String) -> Void)?
     var pymobiledevicePath: String?
 
+    /// Reports progress of device operations so the UI can show something during the
+    /// seconds a userspace tunnel takes to come up, rather than appearing frozen.
+    var onActivity: ((DeviceActivity) -> Void)?
+
+    /// Called with each coordinate `simulate-location play` actually applies, so the map
+    /// can follow the device instead of animating on an independent clock.
+    var onLocationPlayed: ((Double, Double) -> Void)?
+
+    /// Partial stderr line carried between reads, since chunks split arbitrarily.
+    private var playbackLogBuffer = ""
+
     // MARK: - Private Properties
 
     private let runnerQueue = DispatchQueue(label: "runnerQueue", qos: .background)
@@ -36,12 +47,25 @@ class Runner {
 
     private var isStopped: Bool = false
 
+    /// Long-lived `simulate-location play` process for route playback, if one is running.
+    private var routePlaybackTask: Process?
+
     // MARK: - Internal Methods
 
     func stop() {
+        stopRoutePlayback()
+
+        // Record before terminating. The termination handlers run asynchronously and
+        // consult this set; clearing it here let a routine SIGTERM traceback reach the
+        // user as an alert. Each handler removes its own PID, so the set drains itself.
+        runnerQueue.sync {
+            for task in tasks where task.isRunning {
+                reapedPIDs.insert(task.processIdentifier)
+            }
+        }
+
         tasks.forEach { $0.terminate() }
         tasks = []
-        reapedPIDs = []
 
         isStopped = true
     }
@@ -109,14 +133,34 @@ class Runner {
             }
             guard !wasReaped else { return }
 
+            // A clean exit is not a failure: `play` logs every waypoint to stderr, so
+            // surfacing stderr unconditionally would alert at the end of every route.
+            guard finished.terminationStatus != 0 else { return }
+
             guard let errorData = try? errorPipe.fileHandleForReading.readToEnd() else { return }
             let errorText = String(decoding: errorData, as: UTF8.self)
             guard !errorText.isEmpty else { return }
+
+            self.onActivity?(.failed(Self.summarize(errorText)))
 
             Task { @MainActor in
                 showAlert(errorText)
             }
         }
+
+        // `simulate-location set` prints wait_return()'s "Press Ctrl+C" banner to stdout
+        // immediately after the location has been applied — use it as a readiness signal.
+        let readyPipe = outputPipe
+        readyPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else { return }
+            if String(decoding: chunk, as: UTF8.self).contains("Ctrl+C") {
+                readyPipe.fileHandleForReading.readabilityHandler = nil
+                self?.onActivity?(.active("Location set"))
+            }
+        }
+
+        onActivity?(.working("Connecting to device…"))
 
         do {
             try task.run()
@@ -143,13 +187,12 @@ class Runner {
 
     func runOnNewIos(
         location: CLLocationCoordinate2D,
-        rsdAddress: String,
-        rsdPort: String,
+        connection: IOSConnection,
         showAlert: @escaping (String) -> Void
     ) async throws {
-        guard !rsdAddress.isEmpty, !rsdPort.isEmpty else {
+        guard let connectionArguments = connection.arguments else {
             Task { @MainActor in
-                showAlert("Please specify RSD ID and Port")
+                showAlert(connection.configurationHint)
             }
             return
         }
@@ -161,18 +204,9 @@ class Runner {
         }
 
         let task = try await self.taskForIOS(
-            args: [
-                "developer",
-                "dvt",
-                "simulate-location",
-                "set",
-                "--rsd",
-                rsdAddress,
-                rsdPort,
-                "--",
-                "\(location.latitude)",
-                "\(location.longitude)"
-            ],
+            args: ["developer", "dvt", "simulate-location", "set"]
+                + connectionArguments
+                + ["--", "\(location.latitude)", "\(location.longitude)"],
             showAlert: showAlert
         )
 
@@ -202,14 +236,34 @@ class Runner {
             }
             guard !wasReaped else { return }
 
+            // A clean exit is not a failure: `play` logs every waypoint to stderr, so
+            // surfacing stderr unconditionally would alert at the end of every route.
+            guard finished.terminationStatus != 0 else { return }
+
             guard let errorData = try? errorPipe.fileHandleForReading.readToEnd() else { return }
             let errorText = String(decoding: errorData, as: UTF8.self)
             guard !errorText.isEmpty else { return }
+
+            self.onActivity?(.failed(Self.summarize(errorText)))
 
             Task { @MainActor in
                 showAlert(errorText)
             }
         }
+
+        // `simulate-location set` prints wait_return()'s "Press Ctrl+C" banner to stdout
+        // immediately after the location has been applied — use it as a readiness signal.
+        let readyPipe = outputPipe
+        readyPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else { return }
+            if String(decoding: chunk, as: UTF8.self).contains("Ctrl+C") {
+                readyPipe.fileHandleForReading.readabilityHandler = nil
+                self?.onActivity?(.active("Location set"))
+            }
+        }
+
+        onActivity?(.working(connection.progressDescription))
 
         do {
             try task.run()
@@ -232,6 +286,152 @@ class Runner {
             }
             return
         }
+    }
+
+    /// Replay an entire route with a single `simulate-location play` process.
+    ///
+    /// `play` walks the GPX inside one DVT session, so it neither spawns a child per waypoint
+    /// nor holds several device sessions open at once.
+    func playRoute(
+        gpxURL: URL,
+        connection: IOSConnection,
+        showAlert: @escaping (String) -> Void
+    ) async throws {
+        guard let connectionArguments = connection.arguments else {
+            Task { @MainActor in
+                showAlert(connection.configurationHint)
+            }
+            return
+        }
+
+        stopRoutePlayback()
+        self.isStopped = false
+        self.playbackLogBuffer = ""
+
+        let task = try await self.taskForIOS(
+            args: ["developer", "dvt", "simulate-location", "play", gpxURL.path] + connectionArguments,
+            showAlert: showAlert
+        )
+
+        self.log?("playing route: \(gpxURL.lastPathComponent)")
+        self.log?("task: \(task.logDescription)")
+
+        let errorPipe = Pipe()
+        task.standardInput = Pipe()
+        task.standardOutput = Pipe()
+        task.standardError = errorPipe
+
+        task.terminationHandler = { [weak self] finished in
+            guard let self = self else { return }
+
+            let wasReaped = self.runnerQueue.sync {
+                self.reapedPIDs.remove(finished.processIdentifier) != nil
+            }
+            guard !wasReaped else { return }
+
+            // A clean exit is not a failure: `play` logs every waypoint to stderr, so
+            // surfacing stderr unconditionally would alert at the end of every route.
+            guard finished.terminationStatus != 0 else { return }
+
+            guard let errorData = try? errorPipe.fileHandleForReading.readToEnd() else { return }
+            let errorText = String(decoding: errorData, as: UTF8.self)
+            guard !errorText.isEmpty else { return }
+
+            self.onActivity?(.failed(Self.summarize(errorText)))
+
+            Task { @MainActor in
+                showAlert(errorText)
+            }
+        }
+
+        // pymobiledevice3 logs every waypoint it applies to stderr. Parse them so the map
+        // can track the device exactly, and so the first one marks playback as started.
+        var announced = false
+        errorPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            guard let self = self else { return }
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else { return }
+
+            self.playbackLogBuffer += String(decoding: chunk, as: UTF8.self)
+            var lines = self.playbackLogBuffer.components(separatedBy: "\n")
+            self.playbackLogBuffer = lines.removeLast()
+
+            for line in lines {
+                guard let range = line.range(of: "set location to ") else { continue }
+
+                if !announced {
+                    announced = true
+                    self.onActivity?(.active("Route playing"))
+                }
+
+                let parts = line[range.upperBound...].split(separator: " ")
+                guard parts.count >= 2,
+                      let latitude = Double(parts[0]),
+                      let longitude = Double(parts[1]) else { continue }
+
+                self.onLocationPlayed?(latitude, longitude)
+            }
+        }
+
+        onActivity?(.working(connection.progressDescription))
+
+        do {
+            try task.run()
+            self.routePlaybackTask = task
+        } catch {
+            Task { @MainActor in
+                showAlert(error.localizedDescription)
+            }
+        }
+    }
+
+    /// First meaningful line of a traceback, for a one-line status message.
+    private static func summarize(_ text: String) -> String {
+        let line = text
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .last { !$0.isEmpty && !$0.hasPrefix("│") && !$0.hasPrefix("╰") && !$0.hasPrefix("╭") }
+        return line ?? "Device operation failed"
+    }
+
+    /// Terminate route playback, if running. Its stderr is suppressed because a SIGTERM
+    /// traceback here is expected rather than an error worth surfacing.
+    func stopRoutePlayback() {
+        guard let task = routePlaybackTask else { return }
+        routePlaybackTask = nil
+
+        guard task.isRunning else { return }
+        runnerQueue.sync { _ = reapedPIDs.insert(task.processIdentifier) }
+
+        // A suspended child would not act on SIGTERM until resumed, so continue it first.
+        kill(task.processIdentifier, SIGCONT)
+        task.terminate()
+    }
+
+    /// Whether a route playback process is currently alive. False once its tunnel has
+    /// died, in which case resuming means rebuilding the remainder rather than SIGCONT.
+    var isPlaybackRunning: Bool {
+        routePlaybackTask?.isRunning == true
+    }
+
+    /// Suspend route playback where it stands.
+    ///
+    /// `play` sleeps between waypoints, so SIGSTOP freezes it mid-route and SIGCONT picks
+    /// up exactly where it left off — no need to regenerate the route or start over.
+    @discardableResult
+    func pauseRoutePlayback() -> Bool {
+        guard let task = routePlaybackTask, task.isRunning else { return false }
+        guard kill(task.processIdentifier, SIGSTOP) == 0 else { return false }
+        onActivity?(.working("Route paused"))
+        return true
+    }
+
+    @discardableResult
+    func resumeRoutePlayback() -> Bool {
+        guard let task = routePlaybackTask, task.isRunning else { return false }
+        guard kill(task.processIdentifier, SIGCONT) == 0 else { return false }
+        onActivity?(.active("Route playing"))
+        return true
     }
 
     func runOnAndroid(
@@ -389,6 +589,13 @@ class Runner {
         let task = Process()
         task.executableURL = path
         task.arguments = args
+
+        // Python block-buffers stdout when it is a pipe rather than a terminal. Without
+        // this, `simulate-location set` parks in sigwait before flushing its readiness
+        // banner, so the UI would wait for a signal that never arrives.
+        var environment = ProcessInfo.processInfo.environment
+        environment["PYTHONUNBUFFERED"] = "1"
+        task.environment = environment
 
         return task
     }

--- a/SimVirtualLocation/Models/AppStorageKey.swift
+++ b/SimVirtualLocation/Models/AppStorageKey.swift
@@ -9,4 +9,5 @@ enum AppStorageKey {
     static let adbPath = "adb_path"
     static let adbDeviceId = "adb_device_id"
     static let isEmulator = "is_emulator"
+    static let useUserspace = "use_userspace_tunnel"
 }

--- a/SimVirtualLocation/Models/DeviceActivity.swift
+++ b/SimVirtualLocation/Models/DeviceActivity.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Progress of a device operation, surfaced in the UI.
+enum DeviceActivity: Equatable {
+    case idle
+    case working(String)
+    case active(String)
+    case failed(String)
+}

--- a/SimVirtualLocation/Models/IOSConnection.swift
+++ b/SimVirtualLocation/Models/IOSConnection.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// How to reach an iOS 17+ device for developer services.
+enum IOSConnection {
+
+    /// Establish the tunnel in-process with pymobiledevice3's userspace network stack.
+    /// Requires no root and no separately started tunnel.
+    case userspace(udid: String)
+
+    /// Use a kernel tunnel already started with `pymobiledevice3 remote start-tunnel`,
+    /// identified by the RSD address and port it printed.
+    case rsd(address: String, port: String)
+
+    /// Arguments selecting this connection, or `nil` when it is not fully configured.
+    var arguments: [String]? {
+        switch self {
+        case .userspace(let udid):
+            guard !udid.isEmpty else { return nil }
+            return ["--userspace", "--udid", udid]
+        case .rsd(let address, let port):
+            guard !address.isEmpty, !port.isEmpty else { return nil }
+            return ["--rsd", address, port]
+        }
+    }
+
+    /// Shown while the connection is being established.
+    var progressDescription: String {
+        switch self {
+        case .userspace:
+            return "Establishing tunnel to device…"
+        case .rsd:
+            return "Connecting over RSD tunnel…"
+        }
+    }
+
+    /// Message shown when `arguments` is `nil`.
+    var configurationHint: String {
+        switch self {
+        case .userspace:
+            return "No device selected. Connect an iPhone over USB and press Refresh."
+        case .rsd:
+            return "Please specify RSD Address and Port"
+        }
+    }
+}

--- a/SimVirtualLocation/Services/IOSUSBDeviceDiscovery.swift
+++ b/SimVirtualLocation/Services/IOSUSBDeviceDiscovery.swift
@@ -11,7 +11,8 @@ enum IOSUSBDeviceDiscovery {
         showAlert: @escaping (String) -> Void,
         log: @escaping (String) -> Void
     ) async throws -> [Device] {
-        let task = try await runner.taskForIOS(args: ["usbmux", "list", "--no-color", "-u"], showAlert: showAlert)
+        // `--no-color` is a global option: pymobiledevice3 rejects it after the subcommand.
+        let task = try await runner.taskForIOS(args: ["--no-color", "usbmux", "list", "-u"], showAlert: showAlert)
 
         let exe = task.executableURL?.path ?? ""
         let args = task.arguments?.joined(separator: " ") ?? ""
@@ -20,6 +21,8 @@ enum IOSUSBDeviceDiscovery {
         let result = try ProcessRunner.run(task)
 
         guard result.terminationStatus == 0 else {
+            let message = String(decoding: result.stderr, as: UTF8.self)
+            log("device list failed: \(message.isEmpty ? "exit \(result.terminationStatus)" : message)")
             throw IOSUSBDiscoveryError.listCommandFailed
         }
 

--- a/SimVirtualLocation/Utilities/GPXRoute.swift
+++ b/SimVirtualLocation/Utilities/GPXRoute.swift
@@ -1,0 +1,117 @@
+import CoreLocation
+import Foundation
+
+/// Builds a timestamped GPX track for `pymobiledevice3 developer dvt simulate-location play`.
+///
+/// `play` walks the whole file inside a single DVT session, sleeping between points according
+/// to their timestamps. Emitting points at a fixed cadence and spacing the timestamps to match
+/// the requested speed reproduces the movement without spawning a child process per waypoint.
+enum GPXRoute {
+
+    enum Failure: LocalizedError {
+        case emptyRoute
+        case writeFailed(underlying: Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .emptyRoute:
+                return "Route has no points to simulate."
+            case .writeFailed(let underlying):
+                return "Could not write the route file: \(underlying.localizedDescription)"
+            }
+        }
+    }
+
+    /// Seconds between emitted track points. `play` sleeps for the gap between timestamps, so
+    /// this is the granularity of the simulated movement.
+    static let sampleInterval: TimeInterval = 1.0
+
+    /// Resample `coordinates` at a constant `speed` (metres per second) and write a GPX file
+    /// into the temporary directory.
+    static func write(coordinates: [CLLocationCoordinate2D], speed: CLLocationSpeed) throws -> URL {
+        let points = resample(coordinates, speed: max(speed, 0.1))
+        guard !points.isEmpty else { throw Failure.emptyRoute }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let start = Date()
+
+        var gpx = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gpx version="1.1" creator="SimVirtualLocation" xmlns="http://www.topografix.com/GPX/1/1">
+          <trk><name>simulated route</name><trkseg>
+
+        """
+
+        for (index, point) in points.enumerated() {
+            let stamp = formatter.string(from: start.addingTimeInterval(Double(index) * sampleInterval))
+            gpx += "    <trkpt lat=\"\(point.latitude)\" lon=\"\(point.longitude)\"><time>\(stamp)</time></trkpt>\n"
+        }
+
+        gpx += """
+          </trkseg></trk>
+        </gpx>
+
+        """
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("simvirtuallocation-route-\(UUID().uuidString).gpx")
+
+        do {
+            try gpx.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            throw Failure.writeFailed(underlying: error)
+        }
+
+        return url
+    }
+
+    /// Walk the polyline at constant speed, emitting one coordinate per `sampleInterval`.
+    private static func resample(
+        _ coordinates: [CLLocationCoordinate2D],
+        speed: CLLocationSpeed
+    ) -> [CLLocationCoordinate2D] {
+        guard coordinates.count > 1 else { return coordinates }
+
+        var cumulative: [CLLocationDistance] = [0]
+        for index in 1..<coordinates.count {
+            let leg = CLLocation.distance(from: coordinates[index - 1], to: coordinates[index])
+            cumulative.append(cumulative[index - 1] + leg)
+        }
+
+        guard let total = cumulative.last, total > 0 else { return [coordinates[0]] }
+
+        let step = speed * sampleInterval
+        var result: [CLLocationCoordinate2D] = []
+        var travelled: CLLocationDistance = 0
+        var segment = 0
+
+        while travelled < total {
+            while segment < cumulative.count - 2, cumulative[segment + 1] < travelled {
+                segment += 1
+            }
+
+            let spanStart = cumulative[segment]
+            let span = cumulative[segment + 1] - spanStart
+            let fraction = span > 0 ? (travelled - spanStart) / span : 0
+
+            let from = coordinates[segment]
+            let to = coordinates[segment + 1]
+
+            result.append(
+                CLLocationCoordinate2D(
+                    latitude: from.latitude + (to.latitude - from.latitude) * fraction,
+                    longitude: from.longitude + (to.longitude - from.longitude) * fraction
+                )
+            )
+
+            travelled += step
+        }
+
+        if let last = coordinates.last {
+            result.append(last)
+        }
+
+        return result
+    }
+}

--- a/SimVirtualLocation/Views/DeviceActivityView.swift
+++ b/SimVirtualLocation/Views/DeviceActivityView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// One-line status for the current device operation, so a slow tunnel does not look frozen.
+struct DeviceActivityView: View {
+    let activity: DeviceActivity
+
+    var body: some View {
+        switch activity {
+        case .idle:
+            EmptyView()
+        case .working(let message):
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text(message).font(.caption).foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        case .active(let message):
+            Label(message, systemImage: "checkmark.circle.fill")
+                .font(.caption)
+                .foregroundColor(.green)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        case .failed(let message):
+            Label(message, systemImage: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundColor(.red)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}

--- a/SimVirtualLocation/Views/LocationSettingsPanel.swift
+++ b/SimVirtualLocation/Views/LocationSettingsPanel.swift
@@ -102,6 +102,14 @@ struct LocationSettingsPanel: View {
                 })
 
                 Button(action: {
+                    locationController.togglePauseSimulation()
+                }, label: {
+                    Text(locationController.isPaused ? "Resume simulation" : "Pause simulation")
+                        .frame(maxWidth: .infinity)
+                })
+                .disabled(!locationController.isSimulating)
+
+                Button(action: {
                     locationController.stopSimulation()
                 }, label: {
                     Text("Stop simulation").frame(maxWidth: .infinity)
@@ -110,10 +118,33 @@ struct LocationSettingsPanel: View {
 
             GroupBox {
                 VStack(alignment: .leading) {
-                    Slider(value: $locationController.speed, in: 5...200, step: 5) {
+                    Slider(
+                        value: $locationController.speed,
+                        in: LocationController.minimumSpeed...LocationController.maximumSpeed,
+                        step: 5
+                    ) {
                         Text("Speed")
                     }
                     Text("\(Int(locationController.speed.rounded(.up))) km/h")
+
+                    if let summary = locationController.routeSummary {
+                        Text(summary)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    HStack {
+                        Text("Arrive in")
+                        TextField("min", text: $locationController.targetDurationMinutes)
+                            .frame(width: 56)
+                        Text("min")
+                        Spacer()
+                        Button("Set speed") {
+                            locationController.applyTargetDuration()
+                        }
+                    }
+                    .disabled(locationController.routeDistance == 0)
                 }
             }
             

--- a/SimVirtualLocation/Views/iOS/iOSDeviceSettings.swift
+++ b/SimVirtualLocation/Views/iOS/iOSDeviceSettings.swift
@@ -70,7 +70,11 @@ struct RSDHelpSheet: View {
 
             Text(
                 """
-                iOS 17+ requires a tunnel to the device (CoreDevice/RemoteXPC). Run a command from the pymobiledevice3 documentation in Terminal—for example, on iOS 17.4+:
+                Only needed when "No root required" is off.
+
+                With that option on, SimVirtualLocation establishes the tunnel in-process using pymobiledevice3's userspace network stack—no Terminal, no sudo, and no address to copy. Just select your device above.
+
+                Turn it off to use a kernel tunnel you started yourself, which is faster for large transfers. Run a command from the pymobiledevice3 documentation in Terminal—for example, on iOS 17.4+:
 
                 sudo python3 -m pymobiledevice3 lockdown start-tunnel
 
@@ -135,14 +139,44 @@ struct iOSDeviceSettings: View {
                     Text("iOS 17+")
                 }
                 if locationController.useRSD {
-                    TextField("RSD Address", text: $locationController.rsdAddress)
-                    TextField("RSD Port", text: $locationController.rsdPort)
+                    Picker("Connection", selection: $locationController.useUserspace) {
+                        Text("Automatic").tag(true)
+                        Text("Manual").tag(false)
+                    }.labelsHidden().pickerStyle(.segmented)
 
-                    Button(action: { showRSDHelp = true }, label: {
-                        Label("Where to get RSD Address and Port", systemImage: "questionmark.circle")
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    })
-                    .buttonStyle(.link)
+                    if locationController.useUserspace {
+                        Text("SimVirtualLocation connects to the device itself. No Terminal needed.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        // No Refresh button here: devices are rescanned automatically, and
+                        // DeviceActivityView reports what is happening while none is found.
+                        Picker("Device:", selection: $locationController.selectedDevice) {
+                            ForEach(locationController.connectedDevices, id: \.id) { device in
+                                Text("\(device.name) (\(device.version))")
+                            }
+                        }
+                        .disabled(locationController.connectedDevices.isEmpty)
+
+                        DeviceActivityView(activity: locationController.activity)
+                    } else {
+                        Text("Use a tunnel you started yourself. Requires Terminal and sudo.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        TextField("RSD Address", text: $locationController.rsdAddress)
+                        TextField("RSD Port", text: $locationController.rsdPort)
+
+                        Button(action: { showRSDHelp = true }, label: {
+                            Label("Where to get RSD Address and Port", systemImage: "questionmark.circle")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        })
+                        .buttonStyle(.link)
+
+                        DeviceActivityView(activity: locationController.activity)
+                    }
                 } else {
                     TextField("Xcode path", text: $locationController.xcodePath)
                     Picker("Device:", selection: $locationController.selectedDevice) {


### PR DESCRIPTION
Using SimVirtualLocation with an iOS 17+ device currently means opening a Terminal, starting a tunnel with `sudo`, copying an RSD address and port into the app by hand, and doing it all again whenever that tunnel drops.

pymobiledevice3 can establish the tunnel in-process with its userspace network stack (`--userspace`), which needs no root. That removes the reason for every step above, so the app can just connect to the device itself.

## Connection: Automatic / Manual

The **iOS 17+** section gains a Connection picker.

**Automatic** (default) passes `--userspace --udid <udid>` and takes the device from the usbmux listing the app already performs. No Terminal, no `sudo`, no RSD fields.

**Manual** keeps the existing RSD Address / Port fields for anyone who prefers a kernel tunnel, which is faster for large transfers. Nothing is removed — this is an added default.

## Device handling

- **Devices are detected automatically.** A rescan runs on a timer, so plugging a phone in is noticed without pressing Refresh. It polls every 3s while waiting and backs off to 15s once a device is attached, where the scan only exists to notice an unplug. The Refresh button is gone from Automatic mode, since it would only do what already happens.
- **Disconnects are reported.** iOS drops the simulated location the moment the tunnel dies, so leaving a green "Location set" on screen is actively misleading. A disconnect now surfaces plainly, and an in-flight route is paused rather than silently resumed later behind the user's back.
- **Progress is shown** while the tunnel comes up, instead of the UI appearing frozen for a few seconds. Readiness is taken from real output — pymobiledevice3 prints its `Ctrl+C` banner once the location has been applied — rather than a guessed delay.

## Route playback

Routes are now replayed by a **single `simulate-location play` process** against a generated GPX, instead of one child process per waypoint.

- The map follows the coordinates `play` reports on stderr, so the marker tracks the device rather than animating on its own clock and drifting.
- Moving the speed slider mid-route rewrites the remainder at the new speed and restarts from where the device actually is, so speed applies to a run already in flight.
- **Pause / Resume** uses SIGSTOP / SIGCONT, so playback continues from where it stopped rather than restarting. If the connection died while paused, Resume rebuilds the remaining route instead, since the old process is gone.
- Route distance and journey time are shown, and a target duration can set the speed — "arrive in 20 minutes" picks the speed the route needs. Distance comes from `MKRoute.distance`, so it is real driving distance. Requests outside the slider's range are clamped and explained rather than silently wrong.

## Bug fix: device discovery has been broken on pymobiledevice3 10.x

`IOSUSBDeviceDiscovery` invoked:

```
pymobiledevice3 usbmux list --no-color -u
```

`--no-color` is a **global** option; 10.x rejects it after the subcommand:

```
Error: No such option: --no-color
```

The command therefore exited non-zero, the error was swallowed into an empty list, and the device dropdown was silently always empty. Moved before the subcommand, and the failure is now logged rather than discarded.

This one is independent of the rest of the PR and can be cherry-picked on its own if you'd prefer.

## Also

- `PYTHONUNBUFFERED=1` on child processes. Python block-buffers stdout when it is a pipe, so the readiness banner never flushed before the process parked in `sigwait`.
- stderr only raises an alert on a non-zero exit. `play` logs every waypoint to stderr, so the previous behaviour would have thrown an alert at the end of every successful route.
- The **iOS 17+** checkbox now defaults to on.
- README documents Automatic mode; the `sudo` instructions move under Manual.

## Verification

Built with `xcodebuild` on a GitHub-hosted `macos-latest` runner and exercised on device: connecting with no Terminal or `sudo` involved, automatic device detection, setting a single location, route playback start to finish, unplugging the cable mid-session and seeing the disconnect reported, and the distance / journey-time readout.

Tested on iPhone 15 Pro Max, iOS 26.5.2, USB.

## Notes for the reviewer

- Pause assumes a suspended `play` process keeps its DVT channel open, which is what holds the location in place. Short pauses behave as expected; a very long one may eventually be torn down by iOS, which is why Resume checks whether the process is still alive and rebuilds the route if not.
- The device rescan shells out to pymobiledevice3, hence the backoff once a device is attached. The two intervals are constants at the top of `LocationController` if you would like them tuned.
- New types are split out rather than left inline: `IOSConnection` and `DeviceActivity` in `Models/`, `GPXRoute` in `Utilities/`, `DeviceActivityView` in `Views/`.

## Environment

- macOS 26.2 (25C56), Apple Silicon
- pymobiledevice3 10.2.3
- iPhone 15 Pro Max, iOS 26.5.2